### PR TITLE
Added 'velocity_controllers/JointPositionController's for pan and tilt links 

### DIFF
--- a/summit_xl_control/config/summit_xl_a_control.yaml
+++ b/summit_xl_control/config/summit_xl_a_control.yaml
@@ -1,22 +1,12 @@
-  joint_blw_velocity_controller:
-    type: velocity_controllers/JointVelocityController
-    joint: summit_xl_a_back_left_wheel_joint
-  joint_brw_velocity_controller:
-    type: velocity_controllers/JointVelocityController
-    joint: summit_xl_a_back_right_wheel_joint
-  joint_frw_velocity_controller:
-    type: velocity_controllers/JointVelocityController
-    joint: summit_xl_a_front_right_wheel_joint
-  joint_flw_velocity_controller:
-    type: velocity_controllers/JointVelocityController
-    joint: summit_xl_a_front_left_wheel_joint
+  joint_pan_position_controller:
+    type: velocity_controllers/JointPositionController
+    joint: summit_xl_a_front_ptz_camera_pan_joint
+    pid: {p: 100.0, i: 0.01, d: 10.0}
 
-#joint_pan_position_controller:
-#  type: position_controllers/JointPositionController
-#  joint: joint_camera_pan
-#joint_tilt_position_controller:
-#  type: position_controllers/JointPositionController
-#  joint: joint_camera_tilt
+  joint_tilt_position_controller:
+    type: velocity_controllers/JointPositionController
+    joint: summit_xl_a_front_ptz_camera_tilt_joint
+    pid: {p: 100.0, i: 0.01, d: 10.0}
 
   robotnik_base_control:
     type        : "diff_drive_controller/DiffDriveController"
@@ -63,8 +53,5 @@
 
 
   joint_read_state_controller:
-    type: joint_state_controller/JointStateController 
+    type: joint_state_controller/JointStateController
     publish_rate: 100.0
-
-
-

--- a/summit_xl_control/launch/summit_xl_control.launch
+++ b/summit_xl_control/launch/summit_xl_control.launch
@@ -12,7 +12,7 @@
   <arg name="has_safety_module" default="false"/>
 
   <!-- Robot - Load joint controller configurations from YAML file to parameter server -->
-  <group unless="$(arg sim)">	  
+  <group unless="$(arg sim)">
 	  <rosparam file="$(find summit_xl_control)/config/summit_xl_$(arg kinematics)_control.yaml" command="load"/>
 	  <param name="robotnik_base_control/joint/back_left_wheel_joint/name" value="$(arg prefix)back_left_wheel_joint"/>
 	  <param name="robotnik_base_control/joint/back_right_wheel_joint/name" value="$(arg prefix)back_right_wheel_joint"/>
@@ -23,39 +23,43 @@
 	  <param name="robotnik_base_control/odom_frame" value="$(arg prefix)odom"/>
 	  <param name="robotnik_base_control/robot_base_frame" value="$(arg prefix)base_footprint"/>
 	  <param name="robotnik_base_control/wheel_diameter" value="$(arg wheel_diameter)"/>
-	  
+
 	  <!-- load the controllers -->
 	  <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
 		output="screen" args="
 		  robotnik_base_control
-		  joint_read_state_controller 
+		  joint_read_state_controller
+      joint_pan_position_controller
+      joint_tilt_position_controller
 		  ">
 	  </node>
-	  
+
   </group>
     <!-- Simulation - Load joint controller configurations from YAML file to parameter server -->
-  <group if="$(arg sim)">	  	  
-	  <rosparam file="$(find summit_xl_control)/config/$(arg prefix)control.yaml" command="load"/>  
-	  
+  <group if="$(arg sim)">
+	  <rosparam file="$(find summit_xl_control)/config/$(arg prefix)control.yaml" command="load"/>
+
 	  <!-- if robot_localization node is launched the controller must not publish the odom tf-->
-	  <param if="$(arg launch_robot_localization)" name="robotnik_base_control/enable_odom_tf" value="false"/>	 
-	  
+	  <param if="$(arg launch_robot_localization)" name="robotnik_base_control/enable_odom_tf" value="false"/>
+
 	   <!-- load the planar ros controllers by urdf -->
 	  <node if="$(arg ros_planar_move_plugin)" name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
-		output="screen" args="		  
-		  joint_read_state_controller 
+		output="screen" args="
+		  joint_read_state_controller
 		  ">
 	  </node>
 	  <!-- load the diff ros controllers -->
 	  <node unless="$(arg ros_planar_move_plugin)" name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
-		output="screen" args="	
+		output="screen" args="
 		  robotnik_base_control
-		  joint_read_state_controller 
+		  joint_read_state_controller
+      joint_pan_position_controller
+      joint_tilt_position_controller
 		  ">
-	  </node>	  
+	  </node>
 
   </group>
-  
+
 
   <node pkg="twist_mux" type="twist_mux" name="twist_mux">
     <rosparam command="load" file="$(find summit_xl_control)/config/twist_mux.yaml" />
@@ -67,6 +71,5 @@
     <remap from="marker" to="twist_marker"/>
   </node>
 
-  
-</launch>
 
+</launch>


### PR DESCRIPTION
The pan & tilt joints of the axis camera on the summit_xl had no apparent control in the package earlier. Also robotnik_sensors/urdf/axis.urdf.xacro had the link listed as a JointPositionController, which has no support for PID params and thus leads to unnatural motions upon setting a target angle. I have created another PR in the robotnik_sensors repository addressing the same (https://github.com/RobotnikAutomation/robotnik_sensors/pull/6 )