### PR TITLE
Added xacro: for cylinder_inertia use in wheel urdfs. 

### DIFF
--- a/summit_xl_control/launch/summit_xl_control.launch
+++ b/summit_xl_control/launch/summit_xl_control.launch
@@ -24,6 +24,8 @@
 	  <param name="robotnik_base_control/wheel_diameter" value="$(arg wheel_diameter)"/>
 	  <param name="robotnik_base_control/track_width" value="$(arg track_width)"/>
 	  <param name="robotnik_base_control/kinematic_mode" value="$(arg kinematics)"/>
+	  <!-- if robot_localization node is launched the controller must not publish the odom tf-->
+	  <param if="$(arg launch_robot_localization)" name="robotnik_base_control/odom_broadcast_tf" value="false"/>
 	  <!-- load the controllers -->
 	  <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
 		output="screen" args="

--- a/summit_xl_description/urdf/wheels/basic_wheel.urdf.xacro
+++ b/summit_xl_description/urdf/wheels/basic_wheel.urdf.xacro
@@ -44,7 +44,7 @@
       <inertial>
         <mass value="${mass}" />
         <origin xyz="0 0 0" />
-        <cylinder_inertia  m="${mass}" r="${radius}" h="${height}" />
+        <xacro:cylinder_inertia  m="${mass}" r="${radius}" h="${height}" />
       </inertial>
     </link>
 

--- a/summit_xl_description/urdf/wheels/omni_wheel.urdf.xacro
+++ b/summit_xl_description/urdf/wheels/omni_wheel.urdf.xacro
@@ -74,7 +74,7 @@
       <inertial>
         <mass value="${omni_wheel_mass}" />
         <origin xyz="0 0 0" />
-        <cylinder_inertia  m="${omni_wheel_mass}" r="${omni_wheel_radius}" h="${omni_wheel_height}" />
+        <xacro:cylinder_inertia  m="${omni_wheel_mass}" r="${omni_wheel_radius}" h="${omni_wheel_height}" />
       </inertial>
     </link>
 

--- a/summit_xl_description/urdf/wheels/rubber_wheel.urdf.xacro
+++ b/summit_xl_description/urdf/wheels/rubber_wheel.urdf.xacro
@@ -58,7 +58,7 @@
       <inertial>
         <mass value="${rubber_wheel_mass}" />
         <origin xyz="0 0 0" />
-        <cylinder_inertia  m="${rubber_wheel_mass}" r="${rubber_wheel_radius}" h="${rubber_wheel_height}" />
+        <xacro:cylinder_inertia  m="${rubber_wheel_mass}" r="${rubber_wheel_radius}" h="${rubber_wheel_height}" />
       </inertial>
     </link>
 


### PR DESCRIPTION
As xacro tags should be used with namespace, this PR fixes this for the usage of the cylinder_inertia macro.
This fixes the warning in Melodic. Furthermore, the urdf will be created correctly for Noetic.

Please see [xacro - ROS Wiki](https://wiki.ros.org/xacro) Section 13. Deprecated Syntax